### PR TITLE
Hot fix: window listener bug removed

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
-import Summary from './pages/summary';
 import { Route, Routes } from "react-router-dom";
+import Summary from './pages/summary';
 import Live from './pages/live';
 import Give from './pages/give';
 import Grow from './pages/grow';

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -5,8 +5,9 @@ import { Link } from 'react-router-dom';
 function Navbar() {
 
     return (
+        <>
         <nav>
-            <Link href="/summary"><img src="" alt='' /></Link>
+            {/* <Link href="/summary"><img src="" alt='' /></Link> */}
             <div className="nav-links" id="navLinks">
                 <ul>
                     <li><Link to="/summary" id="homeNav">SUMMARY</Link></li>
@@ -18,6 +19,7 @@ function Navbar() {
                 </ul>
             </div>
         </nav>
+        </>
     );
 }
 

--- a/src/pages/summary.js
+++ b/src/pages/summary.js
@@ -317,36 +317,35 @@ function Summary() {
 
         function animateChart()
         {
-          let scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+          if(window.location.pathname !== "/summary"){
+            
+            window.removeEventListener("scroll", animateChart); // if user moves off page, delete listener
           
-              let canvas = (canvasRef || '').current;
-              let chartError = (chartErrorRef || '').current;
+          }else{
+            
+            let scrollTop = window.pageYOffset || document.documentElement.scrollTop;
           
-              if (chartDisplayed && scrollTop < 200) {
-                chartDisplayed = false;
-                canvas.style.opacity = 0;
-                canvas.style.transition = "opacity 0.5s ease-in-out";
-              }
-          
-              if (!chartDisplayed && scrollTop >= 200) {
-                chartDisplayed = true;
-                canvas.style.opacity = 1;
-                canvas.style.transition = "opacity 0.5s ease-in-out";
-                displayChart();
-              }
-        }
-
-        function destroyListener()
-        {
-          if(window.location.pathname !== "/summary")
-            {
-              window.removeEventListener("scroll", animateChart);
-              window.removeEventListener("scroll", destroyListener);
+            let canvas = (canvasRef || '').current;
+            let chartError = (chartErrorRef || '').current;
+        
+            if (chartDisplayed && scrollTop < 200) {
+              chartDisplayed = false;
+              canvas.style.opacity = 0;
+              canvas.style.transition = "opacity 0.5s ease-in-out";
             }
+        
+            if (!chartDisplayed && scrollTop >= 200) {
+              chartDisplayed = true;
+              canvas.style.opacity = 1;
+              canvas.style.transition = "opacity 0.5s ease-in-out";
+              displayChart();
+            }
+          }
+          
         }
+            
         useEffect(() => {
           window.addEventListener("scroll", animateChart);
-          window.addEventListener("scroll", destroyListener);
           }, []);
 
                 

--- a/src/pages/summary.js
+++ b/src/pages/summary.js
@@ -314,14 +314,10 @@ function Summary() {
                 }); 
             }
         }
-       
-          useEffect(() => {
-            displayChart();
-          },[]);
 
-        useEffect(() => {
-            window.addEventListener("scroll", function() {
-              let scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+        function animateChart()
+        {
+          let scrollTop = window.pageYOffset || document.documentElement.scrollTop;
           
               let canvas = (canvasRef || '').current;
               let chartError = (chartErrorRef || '').current;
@@ -338,7 +334,19 @@ function Summary() {
                 canvas.style.transition = "opacity 0.5s ease-in-out";
                 displayChart();
               }
-            });
+        }
+
+        function destroyListener()
+        {
+          if(window.location.pathname !== "/summary")
+            {
+              window.removeEventListener("scroll", animateChart);
+              window.removeEventListener("scroll", destroyListener);
+            }
+        }
+        useEffect(() => {
+          window.addEventListener("scroll", animateChart);
+          window.addEventListener("scroll", destroyListener);
           }, []);
 
                 


### PR DESCRIPTION
- Essentially the animateChart() function added a window event listener that never got removed when navigating to other pages.
- Added a check to see if the page is still the same, if not it destroys the listener
- Temporary fix -- should be updated to a React viewport library such as react-in-viewport 